### PR TITLE
oprava strankovani blogu (blog pagination fix)

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -27,9 +27,9 @@ keywords: články, jihočeši, politika, pohled
       {% for page in (1..paginator.total_pages) %}
       <li>
         {% if forloop.index == 1 %}
-        <a href="/" aria-label="Page {{ forloop.index }}" {% if page == paginator.page %} class="current" {% endif %}>
+        <a href="/blog" aria-label="Page {{ forloop.index }}" {% if page == paginator.page %} class="current" {% endif %}>
       {% else %}
-        <a href="/blog/{{forloop.index}}/" aria-label="Page {{ forloop.index }}"{% if page == paginator.page %} class="current"{% endif %}>
+        <a href="/blog/page{{forloop.index}}/" aria-label="Page {{ forloop.index }}"{% if page == paginator.page %} class="current"{% endif %}>
       {% endif %}
         {{ forloop.index }}
       </a>


### PR DESCRIPTION
- odkaz na prvni stranku prehledu clanku blogu zmenen z / na /blog
- odkaz na kazdou dalsi zmenen z /blog/<<cislo-stranky>> na /blog/page<<cislo-stranky>>

=>vysledek - moznost dostat se ke starsim clankum (EDIT: nejen pres cudliky "predchozi" a "dalsi" - ty fungovali jiz pred upravou korektne) kliknutim na konkretni stranku vysledku

(muj prvni commit, na localhostu mi to funguje, acc na foru piratu: donar)