### PR TITLE
Revert "oprava strankovani blogu (blog pagination fix)"

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -27,9 +27,9 @@ keywords: články, jihočeši, politika, pohled
       {% for page in (1..paginator.total_pages) %}
       <li>
         {% if forloop.index == 1 %}
-        <a href="/blog" aria-label="Page {{ forloop.index }}" {% if page == paginator.page %} class="current" {% endif %}>
+        <a href="/" aria-label="Page {{ forloop.index }}" {% if page == paginator.page %} class="current" {% endif %}>
       {% else %}
-        <a href="/blog/page{{forloop.index}}/" aria-label="Page {{ forloop.index }}"{% if page == paginator.page %} class="current"{% endif %}>
+        <a href="/blog/{{forloop.index}}/" aria-label="Page {{ forloop.index }}"{% if page == paginator.page %} class="current"{% endif %}>
       {% endif %}
         {{ forloop.index }}
       </a>


### PR DESCRIPTION
Reverts pirati-web/jihocesky.pirati.cz#2
U článků zmizí fotografie a strankovani nefunguje - vše od stranky 2. je rozozená celá stránka, chybí články a odkazuje asi někam na střední čechy, zahlédl jsem jméno Vašíček